### PR TITLE
Fixes issues with improper trimming.

### DIFF
--- a/modules/tex/file_re_tex.py
+++ b/modules/tex/file_re_tex.py
@@ -291,7 +291,7 @@ class MipData():
             lineBytelength = self.calculateLineBytelength(ddsBPPs, width)
             self.storeTrimmed(mipData, self.textureData,
                               self.scanlineLength, lineBytelength,
-                              endSize)
+                              expectedMipSize)
         else:
             if mipData != None:
                 self.textureData = mipData.getvalue()

--- a/modules/tex/format_ops.py
+++ b/modules/tex/format_ops.py
@@ -41,7 +41,7 @@ def decomposeRGBFormat(rgb):
     return bitlen,channels
 
 
-class formatData():
+class FormatData():
     """ Container for Format Texel Information 
     Members: 
         tx : Int
@@ -96,7 +96,7 @@ def _packetSizeData(formatString):
         return 1,1,bitlen,bytelen,channels,rgb.groups()[-1]
 
 def packetSizeData(formatString):
-    return formatData(formatString)
+    return FormatData(formatString)
 
 def scanlineMinima(formatString):
     '''X Pixel Count, Y Pixel Count, Bitcount, Bytecount'''

--- a/modules/tex/re_tex_utils.py
+++ b/modules/tex/re_tex_utils.py
@@ -96,10 +96,10 @@ def makeTexHeader(texVersion, ddsHeader, imageCount):
     texHeader.version = texVersion
     texHeader.width = ddsHeader.dwWidth
     texHeader.height = ddsHeader.dwHeight
-    texHeader.depth = 1
+    texHeader.depth = ddsHeader.dwDepth
     texHeader.imageCount = imageCount
     texHeader.mipCount = ddsHeader.dwMipMapCount  # For DMC5/RE2
-    texHeader.imageMipHeaderSize = ddsHeader.dwMipMapCount * 16
+    texHeader.imageMipHeaderSize = ddsHeader.dwMipMapCount << 4
     #texHeader.imageCount = (ddsHeader.dwMipMapCount << 12) | imageCount
     #print(f"imageCount {imageCount}")
     #print(f"dwMipMapCount {ddsHeader.dwMipMapCount}")

--- a/re-mesh-editor_updater/RE-Mesh-Editor_updater_status.json
+++ b/re-mesh-editor_updater/RE-Mesh-Editor_updater_status.json
@@ -1,0 +1,9 @@
+{
+    "last_check": "",
+    "backup_date": "",
+    "update_ready": false,
+    "ignore": false,
+    "just_restored": false,
+    "just_updated": false,
+    "version_text": {}
+}


### PR DESCRIPTION
Fixes an issue that arises from sub-texel size textures having their read length improperly calculated to intra-texel boundaries, resulting in corruption. It has been fixed by removing the calculations centered around the bpps (bits per pixel) and instead directly using the format texel information to calculate this values rather than a lot of arithmetic (that was also wrong).